### PR TITLE
Add dimension parameter to contractor; refactor for type stability

### DIFF
--- a/src/IntervalConstraintProgramming.jl
+++ b/src/IntervalConstraintProgramming.jl
@@ -32,5 +32,4 @@ include("setinversion.jl")
 include("volume.jl")
 include("functions.jl")
 
-
 end # module

--- a/src/ast.jl
+++ b/src/ast.jl
@@ -35,7 +35,7 @@ immutable FunctionAssignment
     f  # function name
     args  # input arguments
     return_arguments
-    intermediate_tuple  # tuple of intermediate variables
+    intermediate  # tuple of intermediate variables
 end
 
 # Close to single assignment form
@@ -155,13 +155,14 @@ function process_tuple!(flatAST::FlatAST, ex)
     # println("Entering process_tuple")
     # @show flatAST
     # @show ex
-    # top_args = [flatten!(flatAST, arg) for arg in ex.args]
 
-    top_args = []  # the arguments returned for each element of the tuple
-    for arg in ex.args
-        top = flatten!(flatAST, arg)
-        push!(top_args, top)
-    end
+    top_args = [flatten!(flatAST, arg) for arg in ex.args]
+
+    # top_args = []  # the arguments returned for each element of the tuple
+    # for arg in ex.args
+    #     top = flatten!(flatAST, arg)
+    #     push!(top_args, top)
+    # end
 
     return top_args
 
@@ -297,14 +298,14 @@ function process_call!(flatAST::FlatAST, ex, new_var=nothing)
             # make enough new variables for all the returned arguments:
             return_args = make_symbols(length(registered_functions[op].return_arguments))
 
-            intermediate_tuple = make_symbol(:z_tuple)
+            intermediate = registered_functions[op].intermediate  # make_symbol(:z_tuple)
 
             add_intermediate!(flatAST, return_args)
-            add_intermediate!(flatAST, intermediate_tuple)
+            add_intermediate!(flatAST, intermediate)
 
-            top_level_code = FunctionAssignment(op, top_args, return_args, intermediate_tuple)
+            top_level_code = FunctionAssignment(op, top_args, return_args, intermediate)
 
-            new_var = return_args 
+            new_var = return_args
 
 
         else

--- a/src/ast.jl
+++ b/src/ast.jl
@@ -32,18 +32,19 @@ immutable Assignment
 end
 
 immutable FunctionAssignment
-    lhs
-    func
-    args
+    f  # function name
+    args  # input arguments
+    return_arguments
+    intermediate_tuple  # tuple of intermediate variables
 end
 
 # Close to single assignment form
 type FlatAST
     top  # topmost variable(s)
     input_variables::Set{Symbol}
-    variables::Vector{Symbol}  # cleaned version
     intermediate::Vector{Symbol}  # generated vars
     code # ::Vector{Assignment}
+    variables::Vector{Symbol}  # cleaned version of input_variables
 end
 
 
@@ -294,13 +295,16 @@ function process_call!(flatAST::FlatAST, ex, new_var=nothing)
         if haskey(registered_functions, op)
 
             # make enough new variables for all the returned arguments:
-            new_vars = make_symbols(length(registered_functions[op].generated))
+            return_args = make_symbols(length(registered_functions[op].return_arguments))
 
-            add_intermediate!(flatAST, new_vars)
+            intermediate_tuple = make_symbol(:z_tuple)
 
-            top_level_code = FunctionAssignment(new_vars, op, top_args)
+            add_intermediate!(flatAST, return_args)
+            add_intermediate!(flatAST, intermediate_tuple)
 
-            new_var = new_vars[1:length(registered_functions[op].return_arguments)]
+            top_level_code = FunctionAssignment(op, top_args, return_args, intermediate_tuple)
+
+            new_var = return_args 
 
 
         else

--- a/src/code_generation.jl
+++ b/src/code_generation.jl
@@ -1,3 +1,13 @@
+# doc"""
+# A generated function, with the code that generated it
+# """
+# immutable GeneratedFunction{F}
+#     f::F
+#     code::Expr
+# end
+#
+# (f::GeneratedFunction{F}){F}(x...) = f.f(x...)
+
 
 function make_tuple(args)
 
@@ -82,7 +92,17 @@ function emit_forward_code(a::FunctionAssignment)
     return_tuple = make_tuple(a.return_arguments)
     intermediate = make_tuple(a.intermediate)
 
-    :( ( $return_tuple, $intermediate ) = $(esc(f)).forward($args_tuple))
+    # Remove the following once https://github.com/JuliaLang/julia/issues/20524 fixed and replace with
+    # :( ( $return_tuple, $intermediate ) = $(esc(f)).forward($args_tuple))
+
+    temp1 = make_symbol(:z_tuple)
+    temp2 = make_symbol(:z_tuple)
+
+    return quote
+        ($temp1, $temp2) = $(esc(f)).forward($args_tuple)
+        $return_tuple = $temp1
+        $intermediate = $temp2
+    end
 end
 
 function emit_backward_code(a::FunctionAssignment)
@@ -93,7 +113,7 @@ function emit_backward_code(a::FunctionAssignment)
 
     intermediate = make_tuple(a.intermediate)
 
-    return_tuple = make_tuple(a.return_arguments)
+    return_tuple = really_make_tuple(a.return_arguments)
 
     :($args_tuple = $(esc(f)).backward($args_tuple, $return_tuple, $intermediate))
 end

--- a/src/code_generation.jl
+++ b/src/code_generation.jl
@@ -30,6 +30,10 @@ function really_make_tuple(args)
     #
     # length(args) == 1 && return args[1]
 
+    # if !(isa(args, Array))
+    #     args = [args]
+    # end
+
     return Expr(:tuple, args...)
 end
 
@@ -87,10 +91,10 @@ function emit_forward_code(a::FunctionAssignment)
     f = a.f
 
     args = isa(a.args, Vector) ? a.args : [a.args]
-    args_tuple = make_tuple(args)
+    args_tuple = really_make_tuple(args)
 
-    return_tuple = make_tuple(a.return_arguments)
-    intermediate = make_tuple(a.intermediate)
+    return_tuple = really_make_tuple(a.return_arguments)
+    intermediate = really_make_tuple(a.intermediate)
 
     # Remove the following once https://github.com/JuliaLang/julia/issues/20524 fixed and replace with
     # :( ( $return_tuple, $intermediate ) = $(esc(f)).forward($args_tuple))
@@ -109,9 +113,9 @@ function emit_backward_code(a::FunctionAssignment)
     f = a.f
 
     args = isa(a.args, Vector) ? a.args : [a.args]
-    args_tuple = make_tuple(args)
+    args_tuple = really_make_tuple(args)
 
-    intermediate = make_tuple(a.intermediate)
+    intermediate = really_make_tuple(a.intermediate)
 
     return_tuple = really_make_tuple(a.return_arguments)
 
@@ -178,8 +182,8 @@ input arguments, output arguments, and code block.
 """
 function make_forward_function(input_args, output_args, intermediate, code)
 
-    input = make_tuple(input_args)  # make a tuple of the variables
-    intermediate = make_tuple(intermediate)
+    input = really_make_tuple(input_args)  # make a tuple of the variables
+    intermediate = really_make_tuple(intermediate)
     output = make_tuple(output_args)  # make a tuple of the variables
 
     quote

--- a/src/code_generation.jl
+++ b/src/code_generation.jl
@@ -141,7 +141,8 @@ function make_function(input_args, output_args, code)
     output = make_tuple(output_args)  # make a tuple of the variables
 
     quote
-        $input -> begin
+        t -> begin
+            $input = t
                     $code
                     return $output
                   end

--- a/src/code_generation.jl
+++ b/src/code_generation.jl
@@ -127,7 +127,14 @@ function forward_backward(flatAST::FlatAST)
     flatAST.variables = input
 
     code = emit_forward_code(flatAST.code)
+
+    @show input
+    @show intermediate
+    @show output
+
+
     forward = make_function(input, [output; intermediate], code)
+
 
     code = emit_backward_code(flatAST.code)
     backward = make_function(input, output, intermediate,
@@ -147,7 +154,7 @@ doc"""
 Generate code for an anonymous function with given
 input arguments, output arguments, and code block.
 """
-function make_function(input_args, output_args, code)
+function make_function(input_args, output_args, intermediate, code)
 
     input = make_tuple(input_args)  # make a tuple of the variables
     output = make_tuple(output_args)  # make a tuple of the variables

--- a/src/code_generation.jl
+++ b/src/code_generation.jl
@@ -133,7 +133,7 @@ function forward_backward(flatAST::FlatAST)
     @show output
 
 
-    forward = make_function(input, [output; intermediate], code)
+    forward = make_function(input, output, intermediate, code)
 
 
     code = emit_backward_code(flatAST.code)
@@ -157,13 +157,14 @@ input arguments, output arguments, and code block.
 function make_function(input_args, output_args, intermediate, code)
 
     input = make_tuple(input_args)  # make a tuple of the variables
+    intermediate = make_tuple(intermediate)
     output = make_tuple(output_args)  # make a tuple of the variables
 
     quote
         t -> begin
             $input = t
                     $code
-                    return $output
+                    return ($output, $intermediate)
                   end
         end
 end

--- a/src/code_generation.jl
+++ b/src/code_generation.jl
@@ -128,9 +128,9 @@ function forward_backward(flatAST::FlatAST)
 
     code = emit_forward_code(flatAST.code)
 
-    @show input
-    @show intermediate
-    @show output
+    # @show input
+    # @show intermediate
+    # @show output
 
 
     forward = make_function(input, output, intermediate, code)

--- a/src/code_generation.jl
+++ b/src/code_generation.jl
@@ -162,11 +162,11 @@ function make_function(input_args, output_args, intermediate, code)
 
     quote
         t -> begin
-            $input = t
-                    $code
-                    return ($output, $intermediate)
-                  end
-        end
+                $input = t
+                $code
+                return ($output, $intermediate)
+             end
+    end
 end
 
 function make_function(input1, input2, input3, output_args, code)
@@ -181,8 +181,8 @@ function make_function(input1, input2, input3, output_args, code)
             $input1 = t1
             $input2 = t2
             $input3 = t3
-                    $code
-                    return $output
-                  end
+            $code
+            return $output
         end
+    end
 end

--- a/src/code_generation.jl
+++ b/src/code_generation.jl
@@ -11,6 +11,18 @@ function make_tuple(args)
     return Expr(:tuple, args...)
 end
 
+function really_make_tuple(args)
+
+    # if isa(args, Symbol)
+    #     # args = [args]
+    #     return args
+    # end
+    #
+    # length(args) == 1 && return args[1]
+
+    return Expr(:tuple, args...)
+end
+
 
 function emit_forward_code(a::Assignment)
 
@@ -118,7 +130,7 @@ function forward_backward(flatAST::FlatAST)
     forward = make_function(input, [output; intermediate], code)
 
     code = emit_backward_code(flatAST.code)
-    backward = make_function([input; output; intermediate],
+    backward = make_function(input, output, intermediate,
                                 input, code)
 
 # @show input
@@ -143,6 +155,24 @@ function make_function(input_args, output_args, code)
     quote
         t -> begin
             $input = t
+                    $code
+                    return $output
+                  end
+        end
+end
+
+function make_function(input1, input2, input3, output_args, code)
+
+    input1 = really_make_tuple(input1)  # make a tuple of the variables
+    input2 = really_make_tuple(input2)
+    input3 = really_make_tuple(input3)
+    output = really_make_tuple(output_args)  # make a tuple of the variables
+
+    quote
+        (t1, t2, t3) -> begin
+            $input1 = t1
+            $input2 = t2
+            $input3 = t3
                     $code
                     return $output
                   end

--- a/src/contractor.jl
+++ b/src/contractor.jl
@@ -57,13 +57,15 @@ end
 
 
 @compat function (C::Contractor{N,Nout,F1,F2}){N,Nout,F1,F2,T}(A::IntervalBox{Nout,T}, X::IntervalBox{N,T}) # X::IntervalBox)
-    z = IntervalBox( C.forward(X))
+
+    output, intermediate = C.forward(X)
+    output_box = IntervalBox(output)
     #z = [1:C.num_outputs] = tuple(IntervalBox(z[1:C.num_outputs]...) ∩ A
 
     # @show z
-    constrained = IntervalBox{Nout,T}(z[1:Nout]) ∩ A
+    constrained = output_box ∩ A
 
-    intermediate = z[Nout+1:end]  # values of intermediate variables from forward run
+    # intermediate = z[Nout+1:end]  # values of intermediate variables from forward run
 
     @show intermediate
     # @show constrained

--- a/src/contractor.jl
+++ b/src/contractor.jl
@@ -46,7 +46,7 @@ end
 @compat (C::Contractor{N,1,F1,F2}){N,F1,F2,T}(A::Interval{T}, X::IntervalBox{N,T}) = C(IntervalBox(A), X)
 
 function make_contractor(ex::Expr)
-    println("Entering Contractor(ex) with ex=$ex")
+    # println("Entering Contractor(ex) with ex=$ex")
     expr, constraint_interval = parse_comparison(ex)
 
     if constraint_interval != entireinterval()
@@ -56,9 +56,9 @@ function make_contractor(ex::Expr)
 
     top, linear_AST = flatten(expr)
 
-     @show expr
-     @show top
-     @show linear_AST
+    #  @show expr
+    #  @show top
+    #  @show linear_AST
 
     forward_code, backward_code  = forward_backward(linear_AST)
 
@@ -70,7 +70,9 @@ function make_contractor(ex::Expr)
         top = [top]
     end
 
-    @show forward_code
+    # @show forward_code
+    # @show backward_code
+
 
     :(Contractor($(linear_AST.variables),
                     $top,

--- a/src/contractor.jl
+++ b/src/contractor.jl
@@ -40,21 +40,6 @@ macro contractor(ex)
     make_contractor(ex)
 end
 
-import Base: ∩, ∪
-
-# TODO: Move these to ValidatedNumerics
-function ∩{N,T}(A::IntervalBox{N,T}, B::IntervalBox{N,T})
-    IntervalBox{N,T}([(a ∩ b) for (a, b) in zip(A, B)])
-end
-
-union{T}(a::Interval{T}, b::Interval{T}) = hull(a, b)
-
-
-function ∪{N,T}(A::IntervalBox{N,T}, B::IntervalBox{N,T})
-    IntervalBox{N,T}([(a ∪ b) for (a, b) in zip(A, B)])
-end
-
-
 
 @compat function (C::Contractor{N,Nout,F1,F2}){N,Nout,F1,F2,T}(A::IntervalBox{Nout,T}, X::IntervalBox{N,T}) # X::IntervalBox)
 

--- a/src/contractor.jl
+++ b/src/contractor.jl
@@ -41,28 +41,20 @@ macro contractor(ex)
 end
 
 
-@compat function (C::Contractor{N,Nout,F1,F2}){N,Nout,F1,F2,T}(A::IntervalBox{Nout,T}, X::IntervalBox{N,T}) # X::IntervalBox)
+@compat function (C::Contractor{N,Nout,F1,F2}){N,Nout,F1,F2,T}(
+    A::IntervalBox{Nout,T}, X::IntervalBox{N,T})
 
     output, intermediate = C.forward(X)
     output_box = IntervalBox(output)
-    #z = [1:C.num_outputs] = tuple(IntervalBox(z[1:C.num_outputs]...) ∩ A
-
-    # @show z
     constrained = output_box ∩ A
 
-    # intermediate = z[Nout+1:end]  # values of intermediate variables from forward run
 
-    # @show intermediate
-    # @show constrained
-
-    # If constrained alread empty, can eliminate call to backward propagation:
+    # if constrained is already empty, eliminate call to backward propagation:
 
     if isempty(constrained)
         return emptyinterval(X)
     end
 
-
-    #@show z[(C.num_outputs)+1:end]
     return IntervalBox{N,T}(C.backward(X, constrained, intermediate) )
 
 end

--- a/src/contractor.jl
+++ b/src/contractor.jl
@@ -40,20 +40,24 @@ macro contractor(ex)
     make_contractor(ex)
 end
 
+import Base.∩
+function ∩{N,T}(A::IntervalBox{N,T}, B::IntervalBox{N,T})
+    IntervalBox{N,T}([(a ∩ b) for (a, b) in zip(A, B)])
+end
 
-@compat function (C::Contractor{N,Nout,F1,F2}){N,Nout,F1,F2,T}(A, X::IntervalBox{N,T}) # X::IntervalBox)
-    z = IntervalBox( C.forward(IntervalBox(X...)...)... )
+@compat function (C::Contractor{N,Nout,F1,F2}){N,Nout,F1,F2,T}(A::IntervalBox{Nout,T}, X::IntervalBox{N,T}) # X::IntervalBox)
+    z = IntervalBox( C.forward(X))
     #z = [1:C.num_outputs] = tuple(IntervalBox(z[1:C.num_outputs]...) ∩ A
 
-    # @show z
-    constrained = IntervalBox(z[1:Nout]...) ∩ IntervalBox(A...)
-    #@show constrained
+     @show z
+    constrained = IntervalBox{Nout,T}(z[1:Nout]) ∩ A
+    @show constrained
     #@show z[(C.num_outputs)+1:end]
-    return IntervalBox( C.backward( X...,
+    return IntervalBox{N,T}( C.backward( IntervalBox(
+                                        X...,
                                     constrained...,
                                     z[Nout+1:end]...
-                                  )...
-                       )
+                                  )))
 end
 
 function make_contractor(ex::Expr)

--- a/src/contractor.jl
+++ b/src/contractor.jl
@@ -67,15 +67,14 @@ end
 
     # intermediate = z[Nout+1:end]  # values of intermediate variables from forward run
 
-    @show intermediate
+    # @show intermediate
     # @show constrained
 
-    # TODO: Add check to see if constrained is empty and therefore can eliminate
-    # backward call:
+    # If constrained alread empty, can eliminate call to backward propagation:
 
-    # if isempty(constrained)
-    #     return emptyinterval(X)
-    # end
+    if isempty(constrained)
+        return emptyinterval(X)
+    end
 
 
     #@show z[(C.num_outputs)+1:end]

--- a/src/contractor.jl
+++ b/src/contractor.jl
@@ -53,11 +53,8 @@ end
     constrained = IntervalBox{Nout,T}(z[1:Nout]) ∩ A
     @show constrained
     #@show z[(C.num_outputs)+1:end]
-    return IntervalBox{N,T}( C.backward( IntervalBox(
-                                        X...,
-                                    constrained...,
-                                    z[Nout+1:end]...
-                                  )))
+    return IntervalBox(C.backward(X, constrained, z[Nout+1:end]) )
+
 end
 
 function make_contractor(ex::Expr)

--- a/src/contractor.jl
+++ b/src/contractor.jl
@@ -40,10 +40,21 @@ macro contractor(ex)
     make_contractor(ex)
 end
 
-import Base.∩
+import Base: ∩, ∪
+
+# TODO: Move these to ValidatedNumerics
 function ∩{N,T}(A::IntervalBox{N,T}, B::IntervalBox{N,T})
     IntervalBox{N,T}([(a ∩ b) for (a, b) in zip(A, B)])
 end
+
+union{T}(a::Interval{T}, b::Interval{T}) = hull(a, b)
+
+
+function ∪{N,T}(A::IntervalBox{N,T}, B::IntervalBox{N,T})
+    IntervalBox{N,T}([(a ∪ b) for (a, b) in zip(A, B)])
+end
+
+
 
 @compat function (C::Contractor{N,Nout,F1,F2}){N,Nout,F1,F2,T}(A::IntervalBox{Nout,T}, X::IntervalBox{N,T}) # X::IntervalBox)
     z = IntervalBox( C.forward(X))
@@ -52,8 +63,12 @@ end
      @show z
     constrained = IntervalBox{Nout,T}(z[1:Nout]) ∩ A
     @show constrained
+
+    # TODO: Add check to see if constrained is empty and therefore can eliminate
+    # backward call
+
     #@show z[(C.num_outputs)+1:end]
-    return IntervalBox(C.backward(X, constrained, z[Nout+1:end]) )
+    return IntervalBox{N,T}(C.backward(X, constrained, z[Nout+1:end]) )
 
 end
 

--- a/src/contractor.jl
+++ b/src/contractor.jl
@@ -29,6 +29,10 @@ end
     A::IntervalBox{Nout,T}, X::IntervalBox{N,T})
 
     output, intermediate = C.forward(X)
+
+    # @show output
+    # @show intermediate
+
     output_box = IntervalBox(output)
     constrained = output_box ∩ A
 
@@ -38,6 +42,10 @@ end
         return emptyinterval(X)
     end
 
+    # @show X
+    # @show constrained
+    # @show intermediate
+    # @show C.backward(X, constrained, intermediate)
     return IntervalBox{N,T}(C.backward(X, constrained, intermediate) )
 
 end

--- a/src/contractor.jl
+++ b/src/contractor.jl
@@ -60,17 +60,29 @@ end
     z = IntervalBox( C.forward(X))
     #z = [1:C.num_outputs] = tuple(IntervalBox(z[1:C.num_outputs]...) ∩ A
 
-     @show z
+    # @show z
     constrained = IntervalBox{Nout,T}(z[1:Nout]) ∩ A
-    @show constrained
+
+    intermediate = z[Nout+1:end]  # values of intermediate variables from forward run
+
+    @show intermediate
+    # @show constrained
 
     # TODO: Add check to see if constrained is empty and therefore can eliminate
-    # backward call
+    # backward call:
+
+    # if isempty(constrained)
+    #     return emptyinterval(X)
+    # end
+
 
     #@show z[(C.num_outputs)+1:end]
-    return IntervalBox{N,T}(C.backward(X, constrained, z[Nout+1:end]) )
+    return IntervalBox{N,T}(C.backward(X, constrained, intermediate) )
 
 end
+
+# allow 1D contractors to take Interval instead of IntervalBox for simplicty:
+@compat (C::Contractor{N,1,F1,F2}){N,F1,F2,T}(A::Interval{T}, X::IntervalBox{N,T}) = C(IntervalBox(A), X)
 
 function make_contractor(ex::Expr)
     # println("Entering Contractor(ex) with ex=$ex")
@@ -88,7 +100,7 @@ function make_contractor(ex::Expr)
 
     num_outputs = isa(linear_AST.top, Symbol) ? 1 : length(linear_AST.top)
 
-    @show top
+    # @show top
 
     if isa(top, Symbol)
         top = [top]

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -13,14 +13,10 @@ type ConstraintFunction{F <: Function, G <: Function}
     backward_code::Expr
 end
 
-type FunctionArguments
-    # input::Vector{Symbol}  # input arguments for forward function
-    # output::Vector{Symbol}  # output arguments
-    # generated::Vector{Symbol} # local variables generated
-
+immutable FunctionArguments
     input
-    generated
     return_arguments
+    intermediate
 end
 
 
@@ -50,13 +46,15 @@ Example: `@function f(x, y) = x^2 + y^2`
     flatAST.intermediate = setdiff(flatAST.intermediate, return_arguments)
 
     # println("HERE")
-    flatAST.intermediate = [return_arguments; flatAST.intermediate]
+    # flatAST.intermediate = [return_arguments; flatAST.intermediate]
 
 
-    registered_functions[f] = FunctionArguments(flatAST.variables, flatAST.intermediate, return_arguments)
+
 
     forward, backward = forward_backward(flatAST)
 
+    registered_functions[f] = FunctionArguments(
+            flatAST.variables, return_arguments, flatAST.intermediate)
 
 
     return quote

--- a/src/separator.jl
+++ b/src/separator.jl
@@ -93,21 +93,21 @@ end
 
 
 function new_parse_comparison(ex)
-    @show ex
+    # @show ex
     if @capture ex begin
             (op_(a_, b_))
         end
 
         #return (op, a, b)
-        @show op, a, b
+        # @show op, a, b
 
     elseif ex.head == :comparison
         println("Comparison")
         symbols = ex.args[1:2:5]
         operators = ex.args[2:2:4]
 
-        @show symbols
-        @show operators
+        # @show symbols
+        # @show operators
 
     end
 end

--- a/src/separator.jl
+++ b/src/separator.jl
@@ -27,20 +27,20 @@ end
     C = S.contractor
     a, b = S.constraint.lo, S.constraint.hi
 
-    inner = C(a..b, X)
+    inner = C(IntervalBox(a..b), X)
 
     local outer
 
     if a == -∞
-        outer = C(b..∞, X)
+        outer = C(IntervalBox(b..∞), X)
 
     elseif b == ∞
-        outer = C(-∞..a, X)
+        outer = C(IntervalBox(-∞..a), X)
 
     else
 
-        outer1 = C(-∞..a, X)
-        outer2 = C(b..∞, X)
+        outer1 = C(IntervalBox(-∞..a), X)
+        outer2 = C(IntervalBox(b..∞), X)
 
         outer = outer1 ∪ outer2
     end

--- a/src/separator.jl
+++ b/src/separator.jl
@@ -27,23 +27,23 @@ end
     C = S.contractor
     a, b = S.constraint.lo, S.constraint.hi
 
-    inner = C(IntervalBox(a..b), X)
+    inner = C(IntervalBox(Interval(a, b)), X)
 
-    local outer
+    #local outer
 
-    if a == -∞
-        outer = C(IntervalBox(b..∞), X)
+    # if a == -∞
+    #     outer = C(IntervalBox(Interval(b, ∞)), X)
+    #
+    # elseif b == ∞
+    #     outer = C(IntervalBox(Interval(-∞, a)), X)
+    #
+    # else
 
-    elseif b == ∞
-        outer = C(IntervalBox(-∞..a), X)
-
-    else
-
-        outer1 = C(IntervalBox(-∞..a), X)
-        outer2 = C(IntervalBox(b..∞), X)
+        outer1 = C(IntervalBox(Interval(-∞, a)), X)
+        outer2 = C(IntervalBox(Interval(b, ∞)), X)
 
         outer = outer1 ∪ outer2
-    end
+    # end
 
     return (inner, outer)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,16 @@ end
 
 end
 
+@testset "Paving a 3D torus" begin
+    S5 = @constraint (3 - sqrt(x^2 + y^2))^2 + z^2 <= 1
+    x = y = z = -∞..∞
+    X = IntervalBox(x, y, z)
+
+    paving = pave(S5, X, 1.)
+
+    @test typeof(paving) == IntervalConstraintProgramming.Paving{3, Float64}
+
+end
 
 @testset "Volume" begin
     x = 3..5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,7 +108,7 @@ end
     @function f(x) = 4x
     C1 = @contractor f(x)
     A = 0.5..1
-    x = 0..1
+    x = IntervalBox(0..1)
 
     @test C1(A, x) == IntervalBox(0.125..0.25)   # x such that 4x ∈ A=[0.5, 1]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,10 +115,10 @@ end
 end
 
 @testset "Functions" begin
-    @function f(x) = 4x
-    C1 = @contractor f(x)
-    A = 0.5..1
-    x = IntervalBox(0..1)
+    @function f(x) = 4x;
+    C1 = @contractor f(x);
+    A = IntervalBox(0.5..1);
+    x = IntervalBox(0..1);
 
     @test C1(A, x) == IntervalBox(0.125..0.25)   # x such that 4x ∈ A=[0.5, 1]
 
@@ -144,8 +144,8 @@ end
 
     C = @contractor g(x)
 
-    A = 0.5..1
-    x = 0..1
+    A = IntervalBox(0.5..1)
+    x = IntervalBox(0..1)
 
     @test C(A, x) == IntervalBox(sqrt(A / 4))
 
@@ -160,8 +160,8 @@ end
 
     @function f(x) = 2x
 
-    A = 0.5..1
-    x = 0..1
+    A = IntervalBox(0.5..1)
+    x = IntervalBox(0..1)
 
     @function g3(x) = ( a = (f↑2)(x); a^2 )
     C3 = @contractor g3(x)


### PR DESCRIPTION
- Make `Contractor` type parametric on the dimension of its input and its output.

- To do so, rewrites `forward` and `backward` code to accept and return tuples to facilitate this, while still remaining type stable.