### PR TITLE
Remove BaseTestNext

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,5 @@
 
-if VERSION >= v"0.5.0-dev+7720"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
 
 using IntervalConstraintProgramming
 using IntervalArithmetic #, IntervalArithmetic.RootFinding


### PR DESCRIPTION
No longer needed after bump to Julia 0.5.