### PR TITLE
Cap Documenter to v0.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ notifications:
   email: false
 
 after_success:
-  - julia -e 'using Pkg; Pkg.add("Documenter")'
+  - julia -e 'using Pkg; ps=PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps)'
   - julia -e 'cd(Pkg.dir("IntervalConstraintProgramming")); include(joinpath("docs", "make.jl"))'
   - julia -e 'cd(Pkg.dir("IntervalConstraintProgramming")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(process_folder())'


### PR DESCRIPTION
Due to upcoming breaking changes in Documenter. This makes sure that the doc builds do not start failing when 0.20 lands in METADATA. [See this thread on Discourse for more information.](https://discourse.julialang.org/t/psa-documenter-jl-breaking-changes-version-capping/16431) 

Ref: JuliaDocs/Documenter.jl#861