### PR TITLE
Make generated functions const

### DIFF
--- a/src/code_generation.jl
+++ b/src/code_generation.jl
@@ -12,6 +12,7 @@ end
 
 (f::GeneratedFunction{F})(x...) where {F} = f.f(x...)
 
+(f::GeneratedFunction{F})(x) where {F} = f.f(x)
 
 function make_tuple(args)
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -71,7 +71,7 @@ const registered_functions = Dict{Symbol, FunctionArguments}()
 
     return quote
 
-        $(esc(f)) =
+        const $(esc(f)) =
             ConstraintFunction($(flatAST.variables),
                                 $(flatAST.intermediate),
                                 $(forward),


### PR DESCRIPTION
Functions with e.g. `@function f(x) = 4x` now make the resulting object `f` be `const`, giving huge speed-ups.

Note that any `@contractor` declaration should also be `const`:

`const C = @contractor f(x)`.