### PR TITLE
added missing ticks in docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # IntervalConstraintProgramming.jl
 
 [![Build Status](https://travis-ci.org/JuliaIntervals/IntervalConstraintProgramming.jl.svg?branch=master)](https://travis-ci.org/dpsanders/IntervalConstraintProgramming.jl)
+[![Docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliaintervals.github.io/pages/packages/intervalconstraintprogramming/)
 
 This Julia package allows us to specify a set of constraints on real-valued variables,
 given by inequalities, and
@@ -12,9 +13,9 @@ The package is based on interval arithmetic using the
 in particular multi-dimensional `IntervalBox`es (i.e. Cartesian products of one-dimensional intervals).
 
 ## Documentation
-Documentation for the package is available [here](http://juliaintervals.github.io/IntervalConstraintProgramming.jl/latest/).
+Documentation for the package is available [here](https://juliaintervals.github.io/pages/packages/intervalconstraintprogramming/).
 
-The best way to learn how to use the package is to look at the example notebooks, available in a separate repository [here](https://github.com/JuliaIntervals/IntervalConstraintProgrammingNotebooks).
+The best way to learn how to use the package is to look at the tutorial, available in the organisation webpage [here](https://juliaintervals.github.io/pages/tutorials/tutorialConstraintProgramming/).
 
 
 ## Author

--- a/src/separator.jl
+++ b/src/separator.jl
@@ -190,10 +190,13 @@ end
 """
 Create a separator without the use of macros using ModelingToolkit
 
-e.g  vars = @variables x y z
+e.g
+```
+vars = @variables x y z
 S = Separator(vars, x^2+y^2<1)
 X= IntervalBox(-0.5..1.5, -0.5..1.5, -0.5..1.5)
 S(X)
+```
 """
 function Separator(variables, ex::Operation)
     expr, constraint = parse_comparison(ex)

--- a/src/separator.jl
+++ b/src/separator.jl
@@ -178,7 +178,7 @@ External constants can be used as e.g. `\$a`:
 
 ```
 a = 3
-C = @constraint x^2 + y^2 <= \$a
+C = @constraint x^2 + y^2 - \$a <= 0
 ```
 """
 macro constraint(ex::Expr, variables = [])


### PR DESCRIPTION
A docstring was not displayed properly in the webpage because of missing ticks around the code snippet. https://juliaintervals.github.io/pages/apiDocs/apiIntervalConstraintProgramming/#Separator this should fix it.