### PR TITLE
Support new package versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,12 +24,12 @@ jobs:
           - os: macOS-latest
             arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:
@@ -42,6 +42,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v6
         with:
           file: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - '1.11'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -11,12 +11,12 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-IntervalArithmetic = "0.22.12"
-IntervalBoxes = "0.2"
-IntervalContractors = "0.5"
-ReversePropagation = "0.3"
+IntervalArithmetic = "0.22.12 - 0.23, 1"
+IntervalBoxes = "0.2 - 0.3"
+IntervalContractors = "0.5 - 0.6"
+ReversePropagation = "0.3 - 0.4"
 StaticArrays = "1"
-Symbolics = "5, 6"
+Symbolics = "5 - 6"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalConstraintProgramming"
 uuid = "138f1668-1576-5ad7-91b9-7425abbf3153"
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ IntervalContractors = "0.5 - 0.6"
 ReversePropagation = "0.3 - 0.4"
 StaticArrays = "1"
 Symbolics = "5 - 6"
-julia = "1"
+julia = "1.11"
 
 [extras]
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,0 @@
-julia 1.0
-ModelingToolkit
-IntervalArithmetic 0.15
-IntervalRootFinding 0.4
-IntervalContractors 0.3
-MacroTools 0.4


### PR DESCRIPTION
I did not apply any code changes, for which I rely on the tests covering the typical use cases.

Note that Symbolics v7 does not seem to work without code changes (lots of warnings printed during the tests, followed by a crash). Hence I only allowed the upper bound v6. All other packages can use the latest version.

cc @blegat